### PR TITLE
Added the relevant sections to install Janus

### DIFF
--- a/roles/install_mjpgstreamer/tasks/recore.yml
+++ b/roles/install_mjpgstreamer/tasks/recore.yml
@@ -50,3 +50,89 @@
   service:
     name: mjpg.service
     enabled: yes
+    
+### Adding this to support the Obico streaming    
+- name: Install Janus dependencies
+  apt:
+    pkg:
+      - libmicrohttpd-dev
+      - libjansson-dev
+      - libssl-dev
+      - libsofia-sip-ua-dev 
+      - libglib2.0-dev 
+      - libopus-dev 
+      - libogg-dev 
+      - libcurl4-openssl-dev 
+      - liblua5.3-dev 
+      - libconfig-dev 
+      - pkg-config 
+      - libtool
+      - automake
+    state: latest
+
+- name: remove the distro cmake (too old)
+  apt:
+    pkg:
+      - cmake
+    state: absent
+
+- name: fetch cmake installer script
+  shell: wget https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-aarch64.sh
+  args:
+    chdir: /opt
+    creates: /opt/cmake-3.25.2-linux-aarch64.sh
+    
+- name: install cmake from installer script
+  shell: bash /opt/cmake-3.25.2-linux-aarch64.sh --skip-license && ln -s /opt/cmake-3.25.2-linux-aarch64/bin/* /usr/local/bin
+  args:
+    chdir: /opt
+    creates: /usr/local/bin/cmake
+
+- name: Install meson & ninja from pip
+  pip:
+    name:
+      - meson>=0.52
+      - ninja
+
+- name: Clone libnice repo
+  git:
+    repo: https://gitlab.freedesktop.org/libnice/libnice
+    dest: /usr/src/libnice
+    depth: 1
+    
+- name: Compile and install libnice
+  shell: meson --prefix=/usr build && ninja -C build && ninja -C build install
+  args:
+    chdir: /usr/src/libnice
+
+- name: install libwebsocket from source
+  shell: |
+    git clone https://libwebsockets.org/repo/libwebsockets
+    cd libwebsockets
+    mkdir build
+    cd build
+    cmake -DLWS_MAX_SMP=1 -DLWS_WITHOUT_EXTENSIONS=0 -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_C_FLAGS="-fpic" ..
+    make && sudo make install
+  args:
+    chdir: /usr/src
+
+- name: Install libsrtp from source
+  shell: |
+    wget https://github.com/cisco/libsrtp/archive/v2.2.0.tar.gz && \
+    tar xfv v2.2.0.tar.gz && \
+    cd libsrtp-2.2.0 && \
+    ./configure --prefix=/usr --enable-openssl && \
+    make shared_library && sudo make install
+  args:
+    chdir: /usr/src/
+  
+- name: clone janus repo
+  git:
+    repo: https://github.com/meetecho/janus-gateway.git
+    dest: /usr/src/janus
+    depth: 1
+    
+- name: autogen janus
+  shell: sh autogen.sh && ./configure --prefix=/opt/janus && make && make install && make configs
+  args:
+    chdir: /usr/src/janus


### PR DESCRIPTION
With the objective of making Obico streaming work with the ReFactor images, a number of dependencies must be installed. Janus is the key step to get running properly, as ffmpeg is already including the necessary encoders and hardware acceleration for the A64 SoC.